### PR TITLE
Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+.env
+.venv/
+venv/
+dist/
+build/
+.git/
+.idea/
+.vscode/
+node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,6 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
-*.db
-*.sqlite3
 .env
 .venv/
 venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.12-slim AS runtime
+FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -7,18 +7,17 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# System deps (add build-essential if you compile wheels)
+# System deps (add build-essential if you compile native wheels)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Poetry
 RUN pip install --upgrade pip poetry
 
-# Copy dependency files first for layer caching
+# Copy dependency files first to leverage docker layer cache
 COPY pyproject.toml poetry.lock* /app/
 
-# Install deps (no venv inside container)
+# Install dependencies (no venv inside container)
 RUN poetry config virtualenvs.create false \
  && poetry install --no-interaction --no-ansi --only main
 
@@ -27,5 +26,4 @@ COPY app /app/app
 
 EXPOSE 8000
 
-# Production: Gunicorn managing Uvicorn workers
 CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "app.main:app", "-b", "0.0.0.0:8000", "--workers", "2", "--timeout", "60"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Dockerfile
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# System deps (add build-essential if you compile wheels)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry
+RUN pip install --upgrade pip poetry
+
+# Copy dependency files first for layer caching
+COPY pyproject.toml poetry.lock* /app/
+
+# Install deps (no venv inside container)
+RUN poetry config virtualenvs.create false \
+ && poetry install --no-interaction --no-ansi --only main
+
+# Copy app code
+COPY app /app/app
+
+EXPOSE 8000
+
+# Production: Gunicorn managing Uvicorn workers
+CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "app.main:app", "-b", "0.0.0.0:8000", "--workers", "2", "--timeout", "60"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from datetime import datetime
 
@@ -16,6 +17,15 @@ app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
 # Jinja2 template directory
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+manifest_path = Path("app/static_manifest.json")
+STATIC_MANIFEST = json.loads(manifest_path.read_text()) if manifest_path.exists() else {}
+
+def static_url(path: str) -> str:
+    # path like "css/site.css"
+    hashed = STATIC_MANIFEST.get(path, path)
+    return f"/static/{hashed}"
+
+templates.env.globals["static_url"] = static_url
 
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,12 @@
 services:
   web:
     build: .
-    container_name: fastapi_web
-    expose:
-      - "8000"
-    environment:
-      - ENV=production
-    restart: unless-stopped
+    expose: ["8000"]
 
   nginx:
     image: nginx:1.27-alpine
-    container_name: fastapi_nginx
-    depends_on:
-      - web
-    ports:
-      - "80:80"
+    depends_on: [web]
+    ports: ["80:80"]
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./app/static:/static:ro
-    restart: unless-stopped
+      - ./app/static_hashed:/static:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      # example settings
+      - ENV=production
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,21 @@
 services:
   web:
     build: .
-    ports:
-      - "8000:8000"
+    container_name: fastapi_web
+    expose:
+      - "8000"
     environment:
-      # example settings
       - ENV=production
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: fastapi_nginx
+    depends_on:
+      - web
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./app/static:/static:ro
     restart: unless-stopped

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,13 +6,22 @@ http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
+  # Basic perf
   sendfile on;
   tcp_nopush on;
+  tcp_nodelay on;
   keepalive_timeout 65;
+  keepalive_requests 1000;
 
-  # Optional: gzip
+  # Small gzip win for HTML/JS/CSS
   gzip on;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+  # ---- Rate limiting (simple spike protection) ----
+  # Per-IP request rate (tune numbers for your site)
+  limit_req_zone $binary_remote_addr zone=req_per_ip:10m rate=10r/s;
+  # Optional: limit concurrent connections per IP
+  limit_conn_zone $binary_remote_addr zone=conn_per_ip:10m;
 
   upstream fastapi_upstream {
     server web:8000;
@@ -23,17 +32,38 @@ http {
     listen 80;
     server_name _;
 
-    # Serve static directly (shared volume mounted at /static)
+    # Limit concurrency a bit (optional)
+    limit_conn conn_per_ip 20;
+
+    # ---- Static: served by Nginx ----
     location /static/ {
       alias /static/;
+
       access_log off;
+      etag on;
+
+      # Long cache (safe if you do cache busting)
       expires 30d;
-      add_header Cache-Control "public, max-age=2592000" always;
+      add_header Cache-Control "public, max-age=2592000, immutable" always;
+
+      # Don’t let static requests consume proxy resources
       try_files $uri =404;
     }
 
-    # Proxy everything else to FastAPI
+    # ---- Health endpoint passthrough ----
+    location = /health {
+      proxy_pass http://fastapi_upstream/health;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # ---- Dynamic routes: proxy to FastAPI ----
     location / {
+      # Apply rate limiting on dynamic routes
+      limit_req zone=req_per_ip burst=40 nodelay;
+
       proxy_pass http://fastapi_upstream;
       proxy_http_version 1.1;
 
@@ -42,12 +72,14 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
 
-      # Useful for HTMX
+      # Helpful for HTMX: keep request IDs around
       proxy_set_header X-Request-ID $request_id;
 
-      # Websocket support if you ever use it
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+      # Buffers protect upstream during spikes (tune modestly)
+      proxy_buffering on;
+      proxy_buffers 16 16k;
+      proxy_busy_buffers_size 32k;
+      proxy_buffer_size 16k;
 
       proxy_read_timeout 60s;
       proxy_send_timeout 60s;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,56 @@
+worker_processes auto;
+
+events { worker_connections 1024; }
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  sendfile on;
+  tcp_nopush on;
+  keepalive_timeout 65;
+
+  # Optional: gzip
+  gzip on;
+  gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+  upstream fastapi_upstream {
+    server web:8000;
+    keepalive 32;
+  }
+
+  server {
+    listen 80;
+    server_name _;
+
+    # Serve static directly (shared volume mounted at /static)
+    location /static/ {
+      alias /static/;
+      access_log off;
+      expires 30d;
+      add_header Cache-Control "public, max-age=2592000" always;
+      try_files $uri =404;
+    }
+
+    # Proxy everything else to FastAPI
+    location / {
+      proxy_pass http://fastapi_upstream;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      # Useful for HTMX
+      proxy_set_header X-Request-ID $request_id;
+
+      # Websocket support if you ever use it
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      proxy_read_timeout 60s;
+      proxy_send_timeout 60s;
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,14 @@ version = "0.1.0"
 description = ""
 authors = ["levwilliamsmm <levwilliamsmm@mindsmechanical.com>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"
 fastapi = "^0.124.0"
 uvicorn = {extras = ["standard"], version = "^0.38.0"}
 jinja2 = "^3.1.6"
+gunicorn = "^23.0.0"
 
 
 [build-system]

--- a/scripts/hash_static.py
+++ b/scripts/hash_static.py
@@ -1,0 +1,32 @@
+import hashlib, json
+from pathlib import Path
+import shutil
+
+STATIC_DIR = Path("app/static")
+OUT_DIR = Path("app/static_hashed")
+MANIFEST = {}
+
+def hash_file(p: Path) -> str:
+    h = hashlib.sha256(p.read_bytes()).hexdigest()[:8]
+    return h
+
+if OUT_DIR.exists():
+    shutil.rmtree(OUT_DIR)
+OUT_DIR.mkdir(parents=True)
+
+for p in STATIC_DIR.rglob("*"):
+    if p.is_dir():
+        continue
+    rel = p.relative_to(STATIC_DIR)
+    digest = hash_file(p)
+
+    # insert hash before suffix: site.css -> site.<hash>.css
+    hashed_name = f"{p.stem}.{digest}{p.suffix}"
+    out_path = OUT_DIR / rel.parent / hashed_name
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(p.read_bytes())
+
+    MANIFEST[str(rel).replace("\\", "/")] = str((rel.parent / hashed_name)).replace("\\", "/")
+
+(Path("app") / "static_manifest.json").write_text(json.dumps(MANIFEST, indent=2))
+print("Wrote manifest with", len(MANIFEST), "files")


### PR DESCRIPTION
Implemented a production-ready container layout for the FastAPI + Jinja2 site with Nginx in front. Nginx now serves /static/* directly (CSS/JS/images) and proxies all dynamic routes to FastAPI (Jinja-rendered pages + HTMX endpoints), reducing load on Python workers during traffic spikes. Added spike-friendly Nginx defaults (keepalive/gzip/buffering), optional rate/connection limiting, and a /health passthrough for monitoring. Implemented a static asset caching strategy (long-lived cache headers) and a cache-busting approach (versioned query strings or hashed filenames via a static_manifest.json + static_url(...) Jinja helper) so clients reliably receive updated assets after deploys.